### PR TITLE
Update .tmux.conf

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,4 +1,9 @@
 setw -g mode-keys vi
+#允许用鼠标切换窗口/调节分屏大小
+setw -g mouse-resize-pane on
+setw -g mouse-select-pane on
+setw -g mouse-select-window on
+setw -g mode-mouse on
 
 set-option -g history-limit 5000
 


### PR DESCRIPTION
允许用鼠标切换窗口/调节分屏大小
具体：
开启用鼠标拖动调节pane的大小（拖动位置是pane之间的分隔线）
开启用鼠标点击pane来激活该pane
开启用鼠标点击来切换活动window（点击位置是状态栏的窗口名称）
开启window/pane里面的鼠标支持（也即可以用鼠标滚轮回滚显示窗口内容，此时还可以用鼠标选取文本）
亲测好用，哈哈！
